### PR TITLE
NtpTrustedTime: Refresh NTP server from resources before requesting time

### DIFF
--- a/core/java/android/util/NtpTrustedTime.java
+++ b/core/java/android/util/NtpTrustedTime.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2011 The Android Open Source Project
+ * Copyright (C) 2018 The LineageOS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,20 +40,22 @@ public class NtpTrustedTime implements TrustedTime {
     private static NtpTrustedTime sSingleton;
     private static Context sContext;
 
-    private final String mServer;
+    private String mServer;
     private final long mTimeout;
 
     private ConnectivityManager mCM;
 
     private boolean mHasCache;
+    private final boolean mHasSecureServer;
     private long mCachedNtpTime;
     private long mCachedNtpElapsedRealtime;
     private long mCachedNtpCertainty;
 
-    private NtpTrustedTime(String server, long timeout) {
+    private NtpTrustedTime(String server, long timeout, boolean hasSecureServer) {
         if (LOGD) Log.d(TAG, "creating NtpTrustedTime using " + server);
         mServer = server;
         mTimeout = timeout;
+        mHasSecureServer = hasSecureServer;
     }
 
     public static synchronized NtpTrustedTime getInstance(Context context) {
@@ -71,7 +74,7 @@ public class NtpTrustedTime implements TrustedTime {
                     resolver, Settings.Global.NTP_TIMEOUT, defaultTimeout);
 
             final String server = secureServer != null ? secureServer : defaultServer;
-            sSingleton = new NtpTrustedTime(server, timeout);
+            sSingleton = new NtpTrustedTime(server, timeout, secureServer != null);
             sContext = context;
         }
 
@@ -101,6 +104,11 @@ public class NtpTrustedTime implements TrustedTime {
 
         if (LOGD) Log.d(TAG, "forceRefresh() from cache miss");
         final SntpClient client = new SntpClient();
+        if (!mHasSecureServer) {
+            mServer = sContext.getResources().getString(
+                com.android.internal.R.string.config_ntpServer);
+            if (LOGD) Log.d(TAG, "NTP server changed to " + mServer);
+        }
         if (client.requestTime(mServer, (int) mTimeout)) {
             mHasCache = true;
             mCachedNtpTime = client.getNtpTime();


### PR DESCRIPTION
 * NtpTrustedTime initialized before carrier/country specific resources
   got loaded, so generally the default NTP server is always in use.
 * Always fetch NTP server from resources unless secure NTP server is
   set to ensure that carrier/country specific customization works.

Change-Id: I9b09680ea5640c35660d1cd0b910af22af930144